### PR TITLE
Revisao de Tipos e Nomes de propriedades

### DIFF
--- a/src/ACBr.Net.NFSe.Test/SetupACBrNFSe.cs
+++ b/src/ACBr.Net.NFSe.Test/SetupACBrNFSe.cs
@@ -22,7 +22,7 @@ namespace ACBr.Net.NFSe.Test
 			//webservices
 			//Configure os dados da cidade e do Certificado aqui
 			acbrNFSe.Configuracoes.WebServices.Ambiente = DFeTipoAmbiente.Homologacao;
-			acbrNFSe.Configuracoes.WebServices.CodMunicipio = 3543402;
+			acbrNFSe.Configuracoes.WebServices.CodigoMunicipio = 3543402;
 
 			acbrNFSe.Configuracoes.Certificados.Certificado = "4E009FA5F9CABB8F";
 			acbrNFSe.Configuracoes.Certificados.Senha = "";

--- a/src/ACBr.Net.NFSe/ACBrNFSe.cs
+++ b/src/ACBr.Net.NFSe/ACBrNFSe.cs
@@ -112,10 +112,10 @@ namespace ACBr.Net.NFSe
 		/// <param name="lote">The lote.</param>
 		/// <returns>RetornoWebservice.</returns>
 		/// <exception cref="NotImplementedException"></exception>
-		public RetornoWebservice ConsultarLoteRps(string protocolo, int lote)
+		public RetornoWebservice ConsultarLoteRps(int lote, string protocolo)
 		{
 			var provider = ProviderManager.GetProvider(Configuracoes);
-			return provider.ConsultarLoteRps(protocolo, lote, NotasFiscais);
+			return provider.ConsultarLoteRps(lote, protocolo, NotasFiscais);
 		}
 
 		/// <summary>

--- a/src/ACBr.Net.NFSe/ACBrNFSeProxy.cs
+++ b/src/ACBr.Net.NFSe/ACBrNFSeProxy.cs
@@ -69,7 +69,7 @@ namespace ACBr.Net.NFSe
 		{
 			try
 			{
-				oACBrNFSe.Configuracoes.WebServices.CodMunicipio = codigoMunicipio;
+				oACBrNFSe.Configuracoes.WebServices.CodigoMunicipio = codigoMunicipio;
 				oACBrNFSe.Configuracoes.WebServices.Ambiente = (DFeTipoAmbiente)tipoAmbiente;
 				oACBrNFSe.Configuracoes.Certificados.Certificado = certificado;
 				oACBrNFSe.Configuracoes.Certificados.Senha = senha;
@@ -89,7 +89,7 @@ namespace ACBr.Net.NFSe
 		public bool SetupPrestador(string cpfCnpj, string inscricaoMunicipal,
 								   string razaoSocial, string nomeFantasia,
 								   string tipoLogradouro, string logradouro, string numero, string complemento, string bairro,
-								   string codigoMunicipio, string nomeMunicipio, string uf, string cep,
+								   int codigoMunicipio, string nomeMunicipio, string uf, string cep,
 								   string ddd, string telefone, string email, ref string mensagemAlerta, ref string mensagemErro)
 		{
 			try
@@ -171,7 +171,7 @@ namespace ACBr.Net.NFSe
 			return true;
 		}
 
-		public bool RPSServico(string itemListaServico, string codigoTributacaoMunicipio, string codigoCNAE, string codigoMunicipio,
+		public bool RPSServico(string itemListaServico, string codigoTributacaoMunicipio, string codigoCNAE, int codigoMunicipio,
 							   string discriminacao, ref string mensagemAlerta, ref string mensagemErro)
 		{
 			try
@@ -235,7 +235,7 @@ namespace ACBr.Net.NFSe
 		public bool RPSPrestador(string cpfCnpj, string inscricaoMunicipal,
 							  string razaoSocial, string nomeFantasia,
 							  string tipoLogradouro, string logradouro, string numero, string complemento, string bairro,
-							  string codigoMunicipio, string nomeMunicipio, string uf, string cep,
+							  int codigoMunicipio, string nomeMunicipio, string uf, string cep,
 							  string ddd, string telefone, string email, ref string mensagemAlerta, ref string mensagemErro)
 		{
 			try
@@ -276,7 +276,7 @@ namespace ACBr.Net.NFSe
 		public bool RPSTomador(string cpfCnpj, string inscricaoMunicipal,
 							  string razaoSocial,
 							  string tipoLogradouro, string logradouro, string numero, string complemento, string bairro,
-							  string codigoMunicipio, string nomeMunicipio, string uf, string cep,
+							  int codigoMunicipio, string nomeMunicipio, string uf, string cep,
 							  string ddd, string telefone, string email, ref string mensagemAlerta, ref string mensagemErro)
 		{
 			try
@@ -335,7 +335,7 @@ namespace ACBr.Net.NFSe
 			return true;
 		}
 
-		public bool RPSOrgaoGerador(string codigoMunicipio, string uf, ref string mensagemAlerta, ref string mensagemErro)
+		public bool RPSOrgaoGerador(int codigoMunicipio, string uf, ref string mensagemAlerta, ref string mensagemErro)
 		{
 			try
 			{
@@ -359,7 +359,7 @@ namespace ACBr.Net.NFSe
 			try
 			{
 				NFSe.ConstrucaoCivil.CodigoObra = codigoObra;
-				NFSe.ConstrucaoCivil.Art = artObra;
+				NFSe.ConstrucaoCivil.ArtObra = artObra;
 			}
 			catch (Exception ex)
 			{
@@ -417,7 +417,7 @@ namespace ACBr.Net.NFSe
 		{
 			try
 			{
-				MensagemRetorno = oACBrNFSe.ConsultarLoteRps(protocolo, numeroLote);
+				MensagemRetorno = oACBrNFSe.ConsultarLoteRps(numeroLote, protocolo);
 				return TrataMensagemRetornoWebservice(ref mensagemAlerta, ref mensagemErro);
 			}
 			catch (Exception ex)

--- a/src/ACBr.Net.NFSe/Configuracao/CfgWebServices.cs
+++ b/src/ACBr.Net.NFSe/Configuracao/CfgWebServices.cs
@@ -70,7 +70,7 @@ namespace ACBr.Net.NFSe.Configuracao
 		/// </summary>
 		/// <value>The uf codigo.</value>
 		[Browsable(true)]
-		public int CodMunicipio { get; set; }
+		public int CodigoMunicipio { get; set; }
 
 		#endregion Properties
 	}

--- a/src/ACBr.Net.NFSe/Nota/DadosConstrucaoCivil.cs
+++ b/src/ACBr.Net.NFSe/Nota/DadosConstrucaoCivil.cs
@@ -49,7 +49,7 @@ namespace ACBr.Net.NFSe.Nota
 
 		public string CodigoObra { get; set; }
 
-		public string Art { get; set; }
+		public string ArtObra { get; set; }
 
 		public string LogradouroObra { get; set; }
 
@@ -61,7 +61,7 @@ namespace ACBr.Net.NFSe.Nota
 
 		public string CepObra { get; set; }
 
-		public string CodigoMunicipioObra { get; set; }
+		public int CodigoMunicipioObra { get; set; }
 
 		public string UFObra { get; set; }
 

--- a/src/ACBr.Net.NFSe/Nota/DadosServico.cs
+++ b/src/ACBr.Net.NFSe/Nota/DadosServico.cs
@@ -66,7 +66,7 @@ namespace ACBr.Net.NFSe.Nota
 
 		public string Discriminacao { get; set; }
 
-		public string CodigoMunicipio { get; set; }
+		public int CodigoMunicipio { get; set; }
 
 		public string Municipio { get; set; }
 

--- a/src/ACBr.Net.NFSe/Nota/Endereco.cs
+++ b/src/ACBr.Net.NFSe/Nota/Endereco.cs
@@ -59,7 +59,7 @@ namespace ACBr.Net.NFSe.Nota
 
 		public string Bairro { get; set; }
 
-		public string CodigoMunicipio { get; set; }
+		public int CodigoMunicipio { get; set; }
 
 		public string Uf { get; set; }
 

--- a/src/ACBr.Net.NFSe/Nota/IdeOrgaoGerador.cs
+++ b/src/ACBr.Net.NFSe/Nota/IdeOrgaoGerador.cs
@@ -47,7 +47,7 @@ namespace ACBr.Net.NFSe.Nota
 
 		#region Propriedades
 
-		public string CodigoMunicipio { get; set; }
+		public int CodigoMunicipio { get; set; }
 
 		public string Uf { get; set; }
 

--- a/src/ACBr.Net.NFSe/Providers/DSF/ProviderDSF.cs
+++ b/src/ACBr.Net.NFSe/Providers/DSF/ProviderDSF.cs
@@ -108,7 +108,7 @@ namespace ACBr.Net.NFSe.Providers.DSF
 			ret.Tomador.Endereco.Complemento = root.ElementAnyNs("ComplementoEnderecoTomador").GetValue<string>();
 			ret.Tomador.Endereco.TipoBairro = root.ElementAnyNs("TipoBairroTomador").GetValue<string>();
 			ret.Tomador.Endereco.Bairro = root.ElementAnyNs("BairroTomador").GetValue<string>();
-			ret.Tomador.Endereco.CodigoMunicipio = root.ElementAnyNs("CidadeTomador").GetValue<string>();
+			ret.Tomador.Endereco.CodigoMunicipio = root.ElementAnyNs("CidadeTomador").GetValue<int>();
 			ret.Tomador.Endereco.Municipio = root.ElementAnyNs("CidadeTomadorDescricao").GetValue<string>();
 			ret.Tomador.Endereco.Cep = root.ElementAnyNs("CEPTomador").GetValue<string>();
 			ret.Tomador.DadosContato.Email = root.ElementAnyNs("EmailTomador").GetValue<string>();
@@ -136,7 +136,7 @@ namespace ACBr.Net.NFSe.Providers.DSF
 			ret.Servico.CodigoCnae = root.ElementAnyNs("CodigoAtividade").GetValue<string>();
 			ret.Servico.Valores.Aliquota = root.ElementAnyNs("AliquotaAtividade").GetValue<decimal>();
 			ret.Servico.Valores.IssRetido = root.ElementAnyNs("TipoRecolhimento").GetValue<char>() == 'A' ? SituacaoTributaria.Normal : SituacaoTributaria.Retencao;
-			ret.Servico.CodigoMunicipio = root.ElementAnyNs("MunicipioPrestacao").GetValue<string>();
+			ret.Servico.CodigoMunicipio = root.ElementAnyNs("MunicipioPrestacao").GetValue<int>();
 			ret.Servico.Municipio = root.ElementAnyNs("MunicipioPrestacaoDescricao").GetValue<string>();
 
 			switch (root.ElementAnyNs("Operacao").GetValue<char>())
@@ -768,7 +768,7 @@ namespace ACBr.Net.NFSe.Providers.DSF
 			return retornoWebservice;
 		}
 
-		public override RetornoWebservice ConsultarLoteRps(string protocolo, int lote, NotaFiscalCollection notas)
+		public override RetornoWebservice ConsultarLoteRps(int lote, string protocolo, NotaFiscalCollection notas)
 		{
             var retornoWebservice = new RetornoWebservice();
 

--- a/src/ACBr.Net.NFSe/Providers/Ginfes/ProviderGinfes.cs
+++ b/src/ACBr.Net.NFSe/Providers/Ginfes/ProviderGinfes.cs
@@ -248,7 +248,7 @@ namespace ACBr.Net.NFSe.Providers.Ginfes
 				ret.Servico.CodigoCnae = rootServico.ElementAnyNs("CodigoCnae")?.GetValue<string>() ?? string.Empty;
 				ret.Servico.CodigoTributacaoMunicipio = rootServico.ElementAnyNs("CodigoTributacaoMunicipio")?.GetValue<string>() ?? string.Empty;
 				ret.Servico.Discriminacao = rootServico.ElementAnyNs("Discriminacao")?.GetValue<string>() ?? string.Empty;
-				ret.Servico.CodigoMunicipio = rootServico.ElementAnyNs("CodigoMunicipio")?.GetValue<string>() ?? string.Empty;
+				ret.Servico.CodigoMunicipio = rootServico.ElementAnyNs("CodigoMunicipio")?.GetValue<int>() ?? 0;
 			}
 			if (formatoXml == LoadXmlFormato.NFSe)
 			{
@@ -276,7 +276,7 @@ namespace ACBr.Net.NFSe.Providers.Ginfes
 						ret.Prestador.Endereco.Numero = rootPrestadorEndereco.ElementAnyNs("Numero")?.GetValue<string>() ?? string.Empty;
 						ret.Prestador.Endereco.Complemento = rootPrestadorEndereco.ElementAnyNs("Complemento")?.GetValue<string>() ?? string.Empty;
 						ret.Prestador.Endereco.Bairro = rootPrestadorEndereco.ElementAnyNs("Bairro")?.GetValue<string>() ?? string.Empty;
-						ret.Prestador.Endereco.CodigoMunicipio = rootPrestadorEndereco.ElementAnyNs("CodigoMunicipio")?.GetValue<string>() ?? string.Empty;
+						ret.Prestador.Endereco.CodigoMunicipio = rootPrestadorEndereco.ElementAnyNs("CodigoMunicipio")?.GetValue<int>() ?? 0;
 						ret.Prestador.Endereco.Uf = rootPrestadorEndereco.ElementAnyNs("Uf")?.GetValue<string>() ?? string.Empty;
 						ret.Prestador.Endereco.Cep = rootPrestadorEndereco.ElementAnyNs("Cep")?.GetValue<string>() ?? string.Empty;
 					}
@@ -326,7 +326,7 @@ namespace ACBr.Net.NFSe.Providers.Ginfes
 					ret.Tomador.Endereco.Numero = rootTomadorEndereco.ElementAnyNs("Numero")?.GetValue<string>() ?? string.Empty;
 					ret.Tomador.Endereco.Complemento = rootTomadorEndereco.ElementAnyNs("Complemento")?.GetValue<string>() ?? string.Empty;
 					ret.Tomador.Endereco.Bairro = rootTomadorEndereco.ElementAnyNs("Bairro")?.GetValue<string>() ?? string.Empty;
-					ret.Tomador.Endereco.CodigoMunicipio = rootTomadorEndereco.ElementAnyNs("CodigoMunicipio")?.GetValue<string>() ?? string.Empty;
+					ret.Tomador.Endereco.CodigoMunicipio = rootTomadorEndereco.ElementAnyNs("CodigoMunicipio")?.GetValue<int>() ?? 0;
 					ret.Tomador.Endereco.Uf = rootTomadorEndereco.ElementAnyNs("Uf")?.GetValue<string>() ?? string.Empty;
 					ret.Tomador.Endereco.Cep = rootTomadorEndereco.ElementAnyNs("Cep")?.GetValue<string>() ?? string.Empty;
 				}
@@ -360,7 +360,7 @@ namespace ACBr.Net.NFSe.Providers.Ginfes
 				var rootOrgaoGerador = rootDoc.ElementAnyNs("OrgaoGerador");
 				if (rootOrgaoGerador != null)
 				{
-					ret.OrgaoGerador.CodigoMunicipio = rootOrgaoGerador.ElementAnyNs("CodigoMunicipio")?.GetValue<string>() ?? string.Empty;
+					ret.OrgaoGerador.CodigoMunicipio = rootOrgaoGerador.ElementAnyNs("CodigoMunicipio")?.GetValue<int>() ?? 0;
 					ret.OrgaoGerador.Uf = rootOrgaoGerador.ElementAnyNs("Uf")?.GetValue<string>() ?? string.Empty;
 				}
 			}
@@ -370,7 +370,7 @@ namespace ACBr.Net.NFSe.Providers.Ginfes
 			if (rootConstrucaoCivil != null)
 			{
 				ret.ConstrucaoCivil.CodigoObra = rootConstrucaoCivil.ElementAnyNs("CodigoObra")?.GetValue<string>() ?? string.Empty;
-				ret.ConstrucaoCivil.Art = rootConstrucaoCivil.ElementAnyNs("Art")?.GetValue<string>() ?? string.Empty;
+				ret.ConstrucaoCivil.ArtObra = rootConstrucaoCivil.ElementAnyNs("Art")?.GetValue<string>() ?? string.Empty;
 			}
 
 			// Verifica se a NFSe está cancelada
@@ -620,10 +620,10 @@ namespace ACBr.Net.NFSe.Providers.Ginfes
 				infNfse.AddChild(conCivil);
 
 				conCivil.AddChild(AdicionarTag(TipoCampo.Str, "", "CodigoObra", ns, 1, 15, Ocorrencia.Obrigatoria, nota.ConstrucaoCivil.CodigoObra));
-				conCivil.AddChild(AdicionarTag(TipoCampo.Str, "", "Art", ns, 1, 15, Ocorrencia.Obrigatoria, nota.ConstrucaoCivil.Art));
+				conCivil.AddChild(AdicionarTag(TipoCampo.Str, "", "Art", ns, 1, 15, Ocorrencia.Obrigatoria, nota.ConstrucaoCivil.ArtObra));
 			}
 
-			if (!nota.OrgaoGerador.CodigoMunicipio.IsEmpty())
+			if (nota.OrgaoGerador.CodigoMunicipio != 0)
 			{
 				var orgGerador = new XElement(ns + "OrgaoGerador");
 				infNfse.AddChild(orgGerador);
@@ -792,7 +792,7 @@ namespace ACBr.Net.NFSe.Providers.Ginfes
 			return retornoWebservice;
 		}
 
-		public override RetornoWebservice ConsultarLoteRps(string protocolo, int lote, NotaFiscalCollection notas)
+		public override RetornoWebservice ConsultarLoteRps(int lote, string protocolo, NotaFiscalCollection notas)
 		{
             var retornoWebservice = new RetornoWebservice();
 
@@ -1332,7 +1332,7 @@ namespace ACBr.Net.NFSe.Providers.Ginfes
 				infoRps.AddChild(conCivil);
 
 				conCivil.AddChild(AdicionarTag(TipoCampo.Str, "", "CodigoObra", ns, 1, 15, Ocorrencia.Obrigatoria, nota.ConstrucaoCivil.CodigoObra));
-				conCivil.AddChild(AdicionarTag(TipoCampo.Str, "", "Art", ns, 1, 15, Ocorrencia.Obrigatoria, nota.ConstrucaoCivil.Art));
+				conCivil.AddChild(AdicionarTag(TipoCampo.Str, "", "Art", ns, 1, 15, Ocorrencia.Obrigatoria, nota.ConstrucaoCivil.ArtObra));
 			}
 
 			return xmlDoc.AsString(identado, showDeclaration, Encoding.UTF8);

--- a/src/ACBr.Net.NFSe/Providers/ProviderBase.cs
+++ b/src/ACBr.Net.NFSe/Providers/ProviderBase.cs
@@ -262,7 +262,7 @@ namespace ACBr.Net.NFSe.Providers
 			throw new NotImplementedException("Função não implementada/suportada neste Provedor !");
 		}
 
-		public virtual RetornoWebservice ConsultarLoteRps(string protocolo, int lote, NotaFiscalCollection notas)
+		public virtual RetornoWebservice ConsultarLoteRps(int lote, string protocolo, NotaFiscalCollection notas)
 		{
 			throw new NotImplementedException("Função não implementada/suportada neste Provedor !");
 		}

--- a/src/ACBr.Net.NFSe/Providers/ProviderManager.cs
+++ b/src/ACBr.Net.NFSe/Providers/ProviderManager.cs
@@ -164,7 +164,7 @@ namespace ACBr.Net.NFSe.Providers
 		/// <returns>Provedor NFSe.</returns>
 		public static ProviderBase GetProvider(ConfiguracoesNFSe config)
 		{
-			var municipio = Municipios.SingleOrDefault(x => x.Codigo == config.WebServices.CodMunicipio);
+			var municipio = Municipios.SingleOrDefault(x => x.Codigo == config.WebServices.CodigoMunicipio);
 			Guard.Against<ACBrException>(municipio == null, "Provedor para esta cidade não implementado ou não especificado!");
 
 			// ReSharper disable once PossibleNullReferenceException


### PR DESCRIPTION
Padronizado o Código do Município como "int CodigoMunicipio" em todas as classes.

Padronizado a ordem dos parâmetros no método ConsultarLoteRps para ficar igual ao método ConsultarSituacao