### PR TITLE
Alteração para configurar webservice Maceió

### DIFF
--- a/src/ACBr.Net.NFSe.Shared/Configuracao/ConfigWebServicesNFSe.cs
+++ b/src/ACBr.Net.NFSe.Shared/Configuracao/ConfigWebServicesNFSe.cs
@@ -81,8 +81,8 @@ namespace ACBr.Net.NFSe.Configuracao
                 if (codigoMunicipio == value) return;
 
                 codigoMunicipio = value;
-                var municipio = ProviderManager.Municipios.SingleOrDefault(x => x.Codigo == codigoMunicipio);
-                Guard.Against<ArgumentException>(municipio == null, "MunicÌpio n„o cadastrado.");
+                var municipio = ProviderManager.Municipios.FirstOrDefault(x => x.Codigo == codigoMunicipio);
+                Guard.Against<ArgumentException>(municipio == null, "Munic√≠pio n√£o cadastrado.");
                 Municipio = municipio.Nome;
             }
         }


### PR DESCRIPTION
Linha 84, estava buscando SingleOrDefault, no caso de Maceió, há 2 registros, 1 com acento e outro sem acento. Neste cado dava erro.
Alterado para FirstOrDefault