### PR TITLE
Alteração GINFEZ Maceió

### DIFF
--- a/src/ACBr.Net.NFSe.Shared/Providers/Ginfes/ProviderGinfes.cs
+++ b/src/ACBr.Net.NFSe.Shared/Providers/Ginfes/ProviderGinfes.cs
@@ -1317,8 +1317,13 @@ namespace ACBr.Net.NFSe.Providers.Ginfes
             // Valor Percentual - Exemplos: 1% => 0.01   /   25,5% => 0.255   /   100% => 1
             valores.AddChild(AdicionarTag(TipoCampo.De4, "", "Aliquota", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.Aliquota / 100));  // Valor Percentual - Exemplos: 1% => 0.01   /   25,5% => 0.255   /   100% => 1
             valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorLiquidoNfse", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.ValorLiquidoNfse));
-            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "DescontoIncondicionado", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.DescontoIncondicionado));
-            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "DescontoCondicionado", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.DescontoCondicionado));
+            
+            if (Municipio.Codigo != 2704302)
+            {
+                //Maceió não permite estas tags
+                valores.AddChild(AdicionarTag(TipoCampo.De2, "", "DescontoIncondicionado", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.DescontoIncondicionado));
+                valores.AddChild(AdicionarTag(TipoCampo.De2, "", "DescontoCondicionado", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.DescontoCondicionado));
+            }
 
             servico.AddChild(AdicionarTag(TipoCampo.Str, "", "ItemListaServico", ns, 1, 5, Ocorrencia.Obrigatoria, nota.Servico.ItemListaServico));
 

--- a/src/ACBr.Net.NFSe.Shared/Providers/Ginfes/ProviderGinfes.cs
+++ b/src/ACBr.Net.NFSe.Shared/Providers/Ginfes/ProviderGinfes.cs
@@ -1318,9 +1318,12 @@ namespace ACBr.Net.NFSe.Providers.Ginfes
             valores.AddChild(AdicionarTag(TipoCampo.De4, "", "Aliquota", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.Aliquota / 100));  // Valor Percentual - Exemplos: 1% => 0.01   /   25,5% => 0.255   /   100% => 1
             valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorLiquidoNfse", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.ValorLiquidoNfse));
             
-            if (Municipio.Codigo != 2704302)
+            //Algumas prefeituras não permitem estas TAGs
+            if (
+                Municipio.Codigo != 2704302 && //Maceió/AL
+                Municipio.Codigo != 3503208 // Araraquara/SP
+                )
             {
-                //Maceió não permite estas tags
                 valores.AddChild(AdicionarTag(TipoCampo.De2, "", "DescontoIncondicionado", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.DescontoIncondicionado));
                 valores.AddChild(AdicionarTag(TipoCampo.De2, "", "DescontoCondicionado", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.DescontoCondicionado));
             }


### PR DESCRIPTION
Removido as TAGs de desconto Incondicionado e Condicionado quando código de município for Maceió, pois a prefeitura não aceita estas TAGs.