### PR TITLE
Remoção TAG ISSQN para Sertãozinho/SP

### DIFF
--- a/src/ACBr.Net.NFSe/Providers/ProviderABRASF204.cs
+++ b/src/ACBr.Net.NFSe/Providers/ProviderABRASF204.cs
@@ -192,6 +192,33 @@ namespace ACBr.Net.NFSe.Providers
 
             return servico;
         }
+        
+        protected virtual XElement WriteValoresRps(NotaFiscal nota)
+        {
+            var valores = new XElement("Valores");
+
+            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorServicos", 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.ValorServicos));
+            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorDeducoes", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorDeducoes));
+            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorPis", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorPis));
+            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorCofins", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorCofins));
+            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorInss", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorInss));
+            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorIr", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorIr));
+            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorCsll", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorCsll));
+            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "OutrasRetencoes", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.OutrasRetencoes));
+            
+            //Algumas prefeituras não permitem TAG de ISSQN, pois são calculadas automaticamente pela prefeitura
+            //Sertãozinho/SP
+            if (!Municipio.Codigo.IsIn(3551702))
+            {
+                valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorIss", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorIss));
+                valores.AddChild(AdicionarTag(TipoCampo.De4, "", "Aliquota", 1, 6, Ocorrencia.MaiorQueZero, nota.Servico.Valores.Aliquota));
+            }
+            
+            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "DescontoIncondicionado", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.DescontoIncondicionado));
+            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "DescontoCondicionado", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.DescontoCondicionado));
+
+            return valores;
+        }
 
         protected override XElement WriteTomadorRps(NotaFiscal nota)
         {


### PR DESCRIPTION
Prefeitura de Sertãozinho/SP não permite informação das Tags de ValorISS e AliquotaISS, pois a prefeitura gera estes valores automaticamente.