### PR TITLE
Ajuste no Provider Ginfes para cidade de Capivari/SP

### DIFF
--- a/src/ACBr.Net.NFSe/Providers/Ginfes/ProviderGinfes.cs
+++ b/src/ACBr.Net.NFSe/Providers/Ginfes/ProviderGinfes.cs
@@ -1162,7 +1162,8 @@ namespace ACBr.Net.NFSe.Providers
             //Algumas prefeituras não permitem estas TAGs
             if (
                 Municipio.Codigo != 2704302 && //Maceió/AL
-                Municipio.Codigo != 3503208 // Araraquara/SP
+                Municipio.Codigo != 3503208 && // Araraquara/SP
+                Municipio.Codigo != 3510401    // Capivari/SP
                 )
             {
                 valores.AddChild(AdicionarTag(TipoCampo.De2, "", "DescontoIncondicionado", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.DescontoIncondicionado));


### PR DESCRIPTION
A cidade de Capivari/SP não aceita as TAG's DescontoIncondicionado e DescontoCondicionado, portanto não devem ser atribuídas no momento da Geração do RPS.