### PR TITLE
Acerto para geração do RPS Ginfes

### DIFF
--- a/src/ACBr.Net.NFSe/Providers/Ginfes/ProviderGinfes.cs
+++ b/src/ACBr.Net.NFSe/Providers/Ginfes/ProviderGinfes.cs
@@ -1143,20 +1143,13 @@ namespace ACBr.Net.NFSe.Providers
             valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorCsll", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.ValorCsll));
 
             valores.AddChild(AdicionarTag(TipoCampo.Int, "", "IssRetido", ns, 1, 1, Ocorrencia.Obrigatoria, issRetido));
-
-            var tipoOcorrenciaValorIss = Ocorrencia.MaiorQueZero;
-            if (regimeEspecialTributacao == "2")
-            {
-                // Se o regime for "Estimativa", obrigatório informar as tags "ValorIss" e "Aliquota"
-                tipoOcorrenciaValorIss = Ocorrencia.Obrigatoria;
-            }
-
-            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorIss", ns, 1, 15, tipoOcorrenciaValorIss, nota.Servico.Valores.ValorIss));
+            
+            valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorIss", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.ValorIss));
             valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorIssRetido", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.ValorIssRetido));
             valores.AddChild(AdicionarTag(TipoCampo.De2, "", "OutrasRetencoes", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.OutrasRetencoes));
             valores.AddChild(AdicionarTag(TipoCampo.De2, "", "BaseCalculo", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.BaseCalculo));
             // Valor Percentual - Exemplos: 1% => 0.01   /   25,5% => 0.255   /   100% => 1
-            valores.AddChild(AdicionarTag(TipoCampo.De4, "", "Aliquota", ns, 1, 15, tipoOcorrenciaValorIss, nota.Servico.Valores.Aliquota / 100));  // Valor Percentual - Exemplos: 1% => 0.01   /   25,5% => 0.255   /   100% => 1
+            valores.AddChild(AdicionarTag(TipoCampo.De4, "", "Aliquota", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.Aliquota / 100));  // Valor Percentual - Exemplos: 1% => 0.01   /   25,5% => 0.255   /   100% => 1
             valores.AddChild(AdicionarTag(TipoCampo.De2, "", "ValorLiquidoNfse", ns, 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.ValorLiquidoNfse));
 
             //Algumas prefeituras não permitem estas TAGs


### PR DESCRIPTION
Acerto para geração do RPS Ginfes - TAG AliquotaISS deve sempre ir no XML, mesmo quando valor = 0