### PR TITLE
Correção de Herança para ABRASF 2.04

### DIFF
--- a/src/ACBr.Net.NFSe/Providers/ProviderABRASF200.cs
+++ b/src/ACBr.Net.NFSe/Providers/ProviderABRASF200.cs
@@ -1495,6 +1495,7 @@ namespace ACBr.Net.NFSe.Providers
                 }
             }
 
+            mensagens = xmlRet?.ElementAnyNs(xmlTag);
             mensagens = mensagens?.ElementAnyNs("ListaMensagemRetornoLote");
             if (mensagens == null) return;
             {

--- a/src/ACBr.Net.NFSe/Providers/ProviderABRASF204.cs
+++ b/src/ACBr.Net.NFSe/Providers/ProviderABRASF204.cs
@@ -40,7 +40,7 @@ namespace ACBr.Net.NFSe.Providers
     /// Classe base para trabalhar com provedores que usam o padrão ABRASF 2.04
     /// </summary>
     /// <seealso cref="ProviderBase" />
-    public abstract class ProviderABRASF204 : ProviderABRASF202
+    public abstract class ProviderABRASF204 : ProviderABRASF203
     {
         #region Constructors
 


### PR DESCRIPTION
Correção de herança para ABRASF 2.04. Estava herdando de 2.02, alterado para 2.03